### PR TITLE
feat: add Next.js frontend and integrate with Aspire

### DIFF
--- a/src/CoffeeTalk.AppHost/CoffeeTalk.AppHost.csproj
+++ b/src/CoffeeTalk.AppHost/CoffeeTalk.AppHost.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.1" />
+    <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.1" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.5.1" />
   </ItemGroup>
 

--- a/src/CoffeeTalk.AppHost/Program.cs
+++ b/src/CoffeeTalk.AppHost/Program.cs
@@ -7,11 +7,16 @@ var postgres = builder.AddPostgres("postgres");
 
 var coffeeTalkDb = postgres.AddDatabase("coffeetalkdb");
 
-builder.AddProject<Projects.CoffeeTalk_Api>("coffeetalk-api")
+var api = builder.AddProject<Projects.CoffeeTalk_Api>("coffeetalk-api")
     .WithReference(coffeeTalkDb);
 
 builder.AddProject<Projects.CoffeeTalk_Migrations>("coffeetalk-migrator")
     .WithReference(coffeeTalkDb)
     .WaitForCompletion(coffeeTalkDb);
+
+builder.AddNpmApp("coffeetalk-web", "../CoffeeTalk.Web")
+    .WithHttpEndpoint(env: "PORT", port: 3000)
+    .WithReference(api)
+    .WithEnvironment("NEXT_PUBLIC_API_BASE_URL", api.GetEndpoint("http"));
 
 builder.Build().Run();

--- a/src/CoffeeTalk.Web/.eslintrc.json
+++ b/src/CoffeeTalk.Web/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "root": true
+}

--- a/src/CoffeeTalk.Web/app/globals.css
+++ b/src/CoffeeTalk.Web/app/globals.css
@@ -1,0 +1,24 @@
+:root {
+  color-scheme: only light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: "Georgia", serif;
+  background: #fdf6e3;
+  color: #4b2e2e;
+}
+
+body {
+  min-height: 100vh;
+}
+
+button {
+  font-family: inherit;
+}

--- a/src/CoffeeTalk.Web/app/layout.tsx
+++ b/src/CoffeeTalk.Web/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Coffee-Time-Music ☕🎶",
+  description: "Brew your beats and sip your style with Coffee-Time."
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/CoffeeTalk.Web/app/page.module.css
+++ b/src/CoffeeTalk.Web/app/page.module.css
@@ -1,0 +1,87 @@
+.page {
+  margin: 0;
+  font-family: "Georgia", serif;
+  background: #fdf6e3;
+  color: #4b2e2e;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1.5rem 4rem;
+  box-sizing: border-box;
+}
+
+.header {
+  font-size: clamp(2rem, 3vw + 1rem, 3rem);
+  margin-bottom: 0.5em;
+}
+
+.tagline {
+  font-size: clamp(1.1rem, 1.5vw + 0.5rem, 1.5rem);
+  margin-bottom: 2em;
+  font-family: "Courier New", monospace;
+  color: #593b3b;
+}
+
+.buttonContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .buttonContainer {
+    flex-direction: row;
+  }
+}
+
+.button {
+  padding: 0.9rem 2.25rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+  font-weight: 600;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.createButton {
+  background-color: #8b5e3c;
+  color: #ffffff;
+}
+
+.createButton:hover {
+  background-color: #a06c48;
+}
+
+.joinButton {
+  background-color: transparent;
+  color: #8b5e3c;
+  border: 2px solid #8b5e3c;
+}
+
+.joinButton:hover {
+  background-color: #f5e6d3;
+}
+
+.footer {
+  position: absolute;
+  bottom: 20px;
+  font-size: 0.9em;
+  color: #7a5c5c;
+}
+
+.footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}

--- a/src/CoffeeTalk.Web/app/page.tsx
+++ b/src/CoffeeTalk.Web/app/page.tsx
@@ -1,0 +1,21 @@
+import styles from "./page.module.css";
+
+export default function Home() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>Coffee-Time ☕🎶</header>
+      <div className={styles.tagline}>Brew your beats. Sip your style.</div>
+      <div className={styles.buttonContainer}>
+        <button className={`${styles.button} ${styles.createButton}`} type="button">
+          Create a Coffee Bar
+        </button>
+        <button className={`${styles.button} ${styles.joinButton}`} type="button">
+          Join a Coffee Bar
+        </button>
+      </div>
+      <footer className={styles.footer}>
+        Hackweek #7 2025 · Made with ☕ by ROAST Hackweek Team
+      </footer>
+    </div>
+  );
+}

--- a/src/CoffeeTalk.Web/next.config.mjs
+++ b/src/CoffeeTalk.Web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/src/CoffeeTalk.Web/package.json
+++ b/src/CoffeeTalk.Web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "coffeetalk-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.79",
+    "@types/react-dom": "18.2.25",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.4.5"
+  }
+}

--- a/src/CoffeeTalk.Web/tsconfig.json
+++ b/src/CoffeeTalk.Web/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a CoffeeTalk Next.js app with the landing page design and supporting TypeScript/ESLint configuration
- enable a reusable styling foundation that matches the provided branding for buttons, header, and layout
- register the frontend with the Aspire AppHost via AddNpmApp and bring in the Node hosting package

## Testing
- npm run lint (from src/CoffeeTalk.Web)
- dotnet build CoffeeTalk.sln


------
https://chatgpt.com/codex/tasks/task_e_68e4ebe32134832ba8a2009c09e23c49