### PR TITLE
Ensure CoffeeTalk web app installs dependencies before starting

### DIFF
--- a/src/CoffeeTalk.Web/package.json
+++ b/src/CoffeeTalk.Web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node ./scripts/start.js",
     "lint": "next lint"
   },
   "dependencies": {

--- a/src/CoffeeTalk.Web/scripts/start.js
+++ b/src/CoffeeTalk.Web/scripts/start.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const projectRoot = join(__dirname, '..');
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const nextExecutable = join(
+  projectRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'next.cmd' : 'next'
+);
+const nextPackageJson = join(projectRoot, 'node_modules', 'next', 'package.json');
+
+if (!existsSync(nextPackageJson)) {
+  console.log('Node modules missing for CoffeeTalk.Web. Installing dependencies...');
+  const installResult = spawnSync(npmExecutable, ['install'], {
+    cwd: projectRoot,
+    stdio: 'inherit'
+  });
+
+  if (installResult.status !== 0) {
+    process.exit(installResult.status ?? 1);
+  }
+} else {
+  console.log('CoffeeTalk.Web dependencies already installed. Skipping npm install.');
+}
+
+if (!existsSync(nextExecutable)) {
+  console.error('Unable to locate the Next.js executable after dependency installation.');
+  process.exit(1);
+}
+
+const startResult = spawnSync(nextExecutable, ['start'], {
+  cwd: projectRoot,
+  stdio: 'inherit'
+});
+
+process.exit(startResult.status ?? 1);


### PR DESCRIPTION
## Summary
- update the CoffeeTalk web start script to run through a Node helper instead of calling Next.js directly
- add a start helper that installs dependencies when node_modules is missing before launching Next.js

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f404d44c832bbe4089e8b80eae4b