### PR TITLE
Reorder app host setup and enable API Swagger

### DIFF
--- a/src/CoffeeTalk.Api/CoffeeTalk.Api.csproj
+++ b/src/CoffeeTalk.Api/CoffeeTalk.Api.csproj
@@ -8,4 +8,7 @@
     <ProjectReference Include="..\CoffeeTalk.Domain\CoffeeTalk.Domain.csproj" />
     <ProjectReference Include="..\CoffeeTalk.ServiceDefaults\CoffeeTalk.ServiceDefaults.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1" />
+  </ItemGroup>
 </Project>

--- a/src/CoffeeTalk.Api/Program.cs
+++ b/src/CoffeeTalk.Api/Program.cs
@@ -7,8 +7,16 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddSingleton<IBrewSessionSummaryProvider, InMemoryBrewSessionSummaryProvider>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 app.MapDefaultEndpoints();
 app.MapBrewSessionEndpoints();

--- a/src/CoffeeTalk.AppHost/Program.cs
+++ b/src/CoffeeTalk.AppHost/Program.cs
@@ -7,16 +7,17 @@ var postgres = builder.AddPostgres("postgres");
 
 var coffeeTalkDb = postgres.AddDatabase("coffeetalkdb");
 
-var api = builder.AddProject<Projects.CoffeeTalk_Api>("coffeetalk-api")
-    .WithReference(coffeeTalkDb);
-
-builder.AddProject<Projects.CoffeeTalk_Migrations>("coffeetalk-migrator")
+var migrations = builder.AddProject<Projects.CoffeeTalk_Migrations>("coffeetalk-migrator")
     .WithReference(coffeeTalkDb)
-    .WaitForCompletion(coffeeTalkDb);
+    .WaitFor(coffeeTalkDb);
+
+var api = builder.AddProject<Projects.CoffeeTalk_Api>("coffeetalk-api")
+    .WithReference(coffeeTalkDb)
+    .WaitForCompletion(migrations);
 
 builder.AddNpmApp("coffeetalk-web", "../CoffeeTalk.Web")
     .WithHttpEndpoint(env: "PORT", port: 3000)
     .WithReference(api)
-    .WithEnvironment("NEXT_PUBLIC_API_BASE_URL", api.GetEndpoint("http"));
+    .WithEnvironment("NEXT_PUBLIC_API_BASE_URL", api.GetEndpoint("https"));
 
 builder.Build().Run();


### PR DESCRIPTION
## Summary
- reorder the distributed app host to create the Postgres database, run migrations, and then start the API before wiring up the web app
- update the web app API base URL to use the API's HTTPS endpoint
- add Swagger services, development middleware, and the Swashbuckle dependency to the CoffeeTalk API

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e4f6906394832bba1f74b60ec3456f