### PR TITLE
Allow local frontend access via CORS and upgrade Next.js

### DIFF
--- a/src/CoffeeTalk.Api/Program.cs
+++ b/src/CoffeeTalk.Api/Program.cs
@@ -13,6 +13,20 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+const string FrontendCorsPolicyName = "Frontend";
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(FrontendCorsPolicyName, policy =>
+    {
+        policy.WithOrigins(
+                "http://localhost:3000",
+                "https://localhost:3000")
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+    });
+});
+
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
@@ -42,6 +56,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseCors(FrontendCorsPolicyName);
 
 app.MapDefaultEndpoints();
 app.MapCoffeeBarEndpoints();

--- a/src/CoffeeTalk.Web/package.json
+++ b/src/CoffeeTalk.Web/package.json
@@ -9,16 +9,16 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.2.5",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "next": "15.5.4",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
   },
   "devDependencies": {
     "@types/node": "20.11.30",
-    "@types/react": "18.2.79",
-    "@types/react-dom": "18.2.25",
+    "@types/react": "19.2.2",
+    "@types/react-dom": "19.2.1",
     "eslint": "8.57.0",
-    "eslint-config-next": "14.2.5",
-    "typescript": "5.4.5"
+    "eslint-config-next": "15.5.4",
+    "typescript": "5.6.3"
   }
 }


### PR DESCRIPTION
## Summary
- configure the API to allow the local Next.js frontend through a dedicated CORS policy
- upgrade Next.js/React and matching type/tooling dependencies to the requested versions

## Testing
- dotnet build
- dotnet test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50115a17c832b9f7542bcddd518da