### PR TITLE
Add coffee bar session management and voting UI

### DIFF
--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/BrewCycleResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/BrewCycleResource.cs
@@ -1,0 +1,12 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record BrewCycleResource(
+    Guid Id,
+    Guid SessionId,
+    Guid IngredientId,
+    string VideoId,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? RevealedAt,
+    bool IsActive,
+    IReadOnlyList<VoteResource> Votes,
+    IReadOnlyList<Guid> SubmitterIds);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/BrewSessionResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/BrewSessionResource.cs
@@ -1,0 +1,6 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record BrewSessionResource(
+    Guid Id,
+    DateTimeOffset StartedAt,
+    IReadOnlyList<BrewCycleResource> Cycles);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CastVoteRequest.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CastVoteRequest.cs
@@ -1,0 +1,3 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record CastVoteRequest(Guid VoterHipsterId, Guid TargetHipsterId);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
@@ -1,3 +1,4 @@
+using CoffeeTalk.Domain.BrewSessions;
 using CoffeeTalk.Domain.CoffeeBars;
 
 namespace CoffeeTalk.Api.Contracts.CoffeeBars;
@@ -18,6 +19,11 @@ public static class CoffeeBarContractsMapper
             .Select(ToResource)
             .ToList();
 
+        var submissions = coffeeBar.Submissions
+            .OrderByDescending(submission => submission.SubmittedAt)
+            .Select(ToResource)
+            .ToList();
+
         return new CoffeeBarResource(
             coffeeBar.Id,
             coffeeBar.Code.Value,
@@ -27,7 +33,8 @@ public static class CoffeeBarContractsMapper
             coffeeBar.SubmissionsLocked,
             coffeeBar.IsClosed,
             hipsters,
-            ingredients);
+            ingredients,
+            submissions);
     }
 
     public static HipsterResource ToResource(Hipster hipster)
@@ -46,5 +53,64 @@ public static class CoffeeBarContractsMapper
             ingredient.VideoId,
             ingredient.IsConsumed,
             ingredient.SubmitterIds.ToList());
+    }
+
+    public static SubmissionResource ToResource(Submission submission)
+    {
+        ArgumentNullException.ThrowIfNull(submission);
+
+        return new SubmissionResource(submission.Id, submission.IngredientId, submission.HipsterId, submission.SubmittedAt);
+    }
+
+    public static BrewSessionResource ToResource(BrewSession session, CoffeeBar coffeeBar)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(coffeeBar);
+
+        var ingredientLookup = coffeeBar.Ingredients.ToDictionary(ingredient => ingredient.Id);
+
+        var cycles = session.Cycles
+            .OrderBy(cycle => cycle.StartedAt)
+            .Select(cycle => ToResource(cycle, ingredientLookup[cycle.IngredientId]))
+            .ToList();
+
+        return new BrewSessionResource(session.Id, session.StartedAt, cycles);
+    }
+
+    public static BrewCycleResource ToResource(BrewCycle cycle, Ingredient ingredient)
+    {
+        ArgumentNullException.ThrowIfNull(cycle);
+        ArgumentNullException.ThrowIfNull(ingredient);
+
+        var votes = cycle.Votes
+            .OrderBy(vote => vote.CastAt)
+            .Select(ToResource)
+            .ToList();
+
+        return new BrewCycleResource(
+            cycle.Id,
+            cycle.SessionId,
+            cycle.IngredientId,
+            ingredient.VideoId,
+            cycle.StartedAt,
+            cycle.RevealedAt,
+            cycle.IsActive,
+            votes,
+            ingredient.SubmitterIds.ToList());
+    }
+
+    public static VoteResource ToResource(Vote vote)
+    {
+        ArgumentNullException.ThrowIfNull(vote);
+
+        return new VoteResource(vote.Id, vote.VoterHipsterId, vote.TargetHipsterId, vote.CastAt, vote.IsCorrect);
+    }
+
+    public static SessionStateResource ToSessionStateResource(CoffeeBar coffeeBar, BrewSession session)
+    {
+        ArgumentNullException.ThrowIfNull(coffeeBar);
+        ArgumentNullException.ThrowIfNull(session);
+
+        return new SessionStateResource(ToResource(coffeeBar), ToResource(session, coffeeBar));
     }
 }

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarResource.cs
@@ -12,4 +12,5 @@ public sealed record CoffeeBarResource(
     bool SubmissionsLocked,
     bool IsClosed,
     IReadOnlyList<HipsterResource> Hipsters,
-    IReadOnlyList<IngredientResource> Ingredients);
+    IReadOnlyList<IngredientResource> Ingredients,
+    IReadOnlyList<SubmissionResource> Submissions);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CreateCoffeeBarRequest.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CreateCoffeeBarRequest.cs
@@ -5,4 +5,5 @@ namespace CoffeeTalk.Api.Contracts.CoffeeBars;
 public sealed record CreateCoffeeBarRequest(
     string Theme,
     int? DefaultMaxIngredientsPerHipster,
-    SubmissionPolicy SubmissionPolicy = SubmissionPolicy.LockOnFirstBrew);
+    SubmissionPolicy SubmissionPolicy = SubmissionPolicy.LockOnFirstBrew,
+    string CreatorUsername = "");

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CreateCoffeeBarResponse.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CreateCoffeeBarResponse.cs
@@ -1,0 +1,3 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record CreateCoffeeBarResponse(CoffeeBarResource CoffeeBar, HipsterResource Hipster);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/SessionStateResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/SessionStateResource.cs
@@ -1,0 +1,3 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record SessionStateResource(CoffeeBarResource CoffeeBar, BrewSessionResource Session);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/SubmissionResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/SubmissionResource.cs
@@ -1,0 +1,7 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record SubmissionResource(
+    Guid Id,
+    Guid IngredientId,
+    Guid HipsterId,
+    DateTimeOffset SubmittedAt);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/VoteResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/VoteResource.cs
@@ -1,0 +1,8 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record VoteResource(
+    Guid Id,
+    Guid VoterHipsterId,
+    Guid TargetHipsterId,
+    DateTimeOffset CastAt,
+    bool? IsCorrect);

--- a/src/CoffeeTalk.Api/Program.cs
+++ b/src/CoffeeTalk.Api/Program.cs
@@ -44,6 +44,7 @@ builder.Services.AddDbContext<CoffeeTalkDbContext>(options =>
 
 builder.Services.AddScoped<ICoffeeBarRepository, CoffeeBarRepository>();
 builder.Services.AddScoped<ICoffeeBarCodeGenerator, CoffeeBarCodeGenerator>();
+builder.Services.AddSingleton<INextIngredientSelector, RandomNextIngredientSelector>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IBrewSessionSummaryProvider, InMemoryBrewSessionSummaryProvider>();
 builder.Services.AddEndpointsApiExplorer();

--- a/src/CoffeeTalk.Api/Services/RandomNextIngredientSelector.cs
+++ b/src/CoffeeTalk.Api/Services/RandomNextIngredientSelector.cs
@@ -1,0 +1,20 @@
+using CoffeeTalk.Domain.CoffeeBars;
+using System.Linq;
+
+namespace CoffeeTalk.Api.Services;
+
+public sealed class RandomNextIngredientSelector : INextIngredientSelector
+{
+    public Ingredient? PickNext(IReadOnlyCollection<Ingredient> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var index = Random.Shared.Next(candidates.Count);
+        return candidates.ElementAt(index);
+    }
+}

--- a/src/CoffeeTalk.Domain/CoffeeBars/Ingredient.cs
+++ b/src/CoffeeTalk.Domain/CoffeeBars/Ingredient.cs
@@ -26,6 +26,14 @@ public sealed class Ingredient
         _submitterIds.Add(hipsterId);
     }
 
+    internal void RemoveSubmission(Guid hipsterId)
+    {
+        if (!_submitterIds.Remove(hipsterId))
+        {
+            throw new DomainException("Hipster has not submitted this ingredient.");
+        }
+    }
+
     internal void MarkConsumed()
     {
         if (IsConsumed)

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
@@ -1,0 +1,326 @@
+.page {
+  min-height: 100vh;
+  background: #fdf6e3;
+  color: #3f2626;
+  padding: 2rem clamp(1rem, 4vw, 4rem);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.loading,
+.error {
+  margin: auto;
+  padding: 1.5rem 2rem;
+  border-radius: 14px;
+  background: rgba(139, 94, 60, 0.08);
+  font-size: 1.1rem;
+  text-align: center;
+  max-width: 32rem;
+}
+
+.error {
+  background: rgba(180, 35, 24, 0.1);
+  color: #7a2118;
+}
+
+.header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.headerTop {
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #7a5c5c;
+}
+
+.title {
+  font-size: clamp(2rem, 3vw + 1rem, 3rem);
+  margin: 0;
+}
+
+.shareHint {
+  font-size: 0.95rem;
+  color: #5a3b33;
+}
+
+.shareAnchor {
+  color: #8b5e3c;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.shareAnchor:hover {
+  text-decoration: underline;
+}
+
+.policy {
+  font-size: 0.9rem;
+  color: #6f4a3f;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1100px) {
+  .layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.sidebar {
+  flex: 0 0 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: #fff7eb;
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(75, 46, 46, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cardTitle {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.hipsterList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hipsterList li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(139, 94, 60, 0.08);
+}
+
+.me {
+  border: 2px solid #8b5e3c;
+  background: rgba(139, 94, 60, 0.16);
+}
+
+.hipsterName {
+  font-weight: 600;
+}
+
+.hipsterCount {
+  font-size: 0.85rem;
+  color: #6f4a3f;
+}
+
+.sessionStatus {
+  font-size: 0.9rem;
+  color: #5a3b33;
+}
+
+.primaryButton {
+  align-self: flex-start;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #8b5e3c, #b5835a);
+  color: #fffaf5;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primaryButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(139, 94, 60, 0.18);
+}
+
+.sessionHint {
+  font-size: 0.85rem;
+  color: #6f4a3f;
+}
+
+.joinForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.input {
+  padding: 0.75rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid #d3b49f;
+  background: #fff;
+  font-size: 1rem;
+  color: #3f2626;
+}
+
+.inlineError {
+  background: rgba(180, 35, 24, 0.1);
+  color: #7a2118;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+}
+
+.identityLine {
+  font-size: 0.95rem;
+  color: #5a3b33;
+}
+
+.submitForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 700px) {
+  .submitForm {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.submissionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.submissionRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(139, 94, 60, 0.08);
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+}
+
+.secondaryButton {
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #8b5e3c;
+  background: transparent;
+  color: #8b5e3c;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.secondaryButton:hover {
+  background: rgba(139, 94, 60, 0.12);
+}
+
+.playerArea {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .playerArea {
+    flex-direction: row;
+  }
+}
+
+.playerWrapper {
+  flex: 2;
+  background: #000;
+  border-radius: 16px;
+  overflow: hidden;
+  position: relative;
+  padding-top: 56.25%;
+}
+
+.player {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.voteSidebar {
+  flex: 1;
+  background: rgba(139, 94, 60, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.voteHeader {
+  font-weight: 700;
+}
+
+.voteSummary {
+  font-size: 0.95rem;
+  color: #5a3b33;
+}
+
+.voteList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.voteButton {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border-radius: 10px;
+  border: none;
+  background: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  color: #3f2626;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.voteButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.voteButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(75, 46, 46, 0.18);
+}

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.tsx
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.tsx
@@ -1,0 +1,663 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import styles from "./CoffeeBarClient.module.css";
+import { getIdentity, removeIdentity, saveIdentity, type HipsterIdentity } from "../../lib/identity";
+
+const API_BASE_URL = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "").replace(/\/$/, "");
+
+type SubmissionPolicy = "LockOnFirstBrew" | "AlwaysOpen";
+
+type HipsterResource = {
+  id: string;
+  username: string;
+  maxIngredientQuota: number;
+};
+
+type IngredientResource = {
+  id: string;
+  videoId: string;
+  isConsumed: boolean;
+  submitterIds: string[];
+};
+
+type SubmissionResource = {
+  id: string;
+  ingredientId: string;
+  hipsterId: string;
+  submittedAt: string;
+};
+
+type CoffeeBarResource = {
+  id: string;
+  code: string;
+  theme: string;
+  defaultMaxIngredientsPerHipster: number;
+  submissionPolicy: SubmissionPolicy;
+  submissionsLocked: boolean;
+  isClosed: boolean;
+  hipsters: HipsterResource[];
+  ingredients: IngredientResource[];
+  submissions: SubmissionResource[];
+};
+
+type SubmitIngredientResponse = {
+  coffeeBar: CoffeeBarResource;
+  ingredient: IngredientResource;
+  submissionId: string;
+};
+
+type JoinCoffeeBarResponse = {
+  coffeeBar: CoffeeBarResource;
+  hipster: HipsterResource;
+};
+
+type VoteResource = {
+  id: string;
+  voterHipsterId: string;
+  targetHipsterId: string;
+  castAt: string;
+  isCorrect: boolean | null;
+};
+
+type BrewCycleResource = {
+  id: string;
+  sessionId: string;
+  ingredientId: string;
+  videoId: string;
+  startedAt: string;
+  revealedAt: string | null;
+  isActive: boolean;
+  votes: VoteResource[];
+  submitterIds: string[];
+};
+
+type BrewSessionResource = {
+  id: string;
+  startedAt: string;
+  cycles: BrewCycleResource[];
+};
+
+type SessionStateResource = {
+  coffeeBar: CoffeeBarResource;
+  session: BrewSessionResource;
+};
+
+type CoffeeBarClientProps = {
+  code: string;
+};
+
+export function CoffeeBarClient({ code }: CoffeeBarClientProps) {
+  const normalizedCode = code.toUpperCase();
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [coffeeBar, setCoffeeBar] = useState<CoffeeBarResource | null>(null);
+  const [sessionState, setSessionState] = useState<SessionStateResource | null>(null);
+  const [identity, setIdentity] = useState<HipsterIdentity | null>(null);
+  const [joinUsername, setJoinUsername] = useState("");
+  const [joinLoading, setJoinLoading] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [urlInput, setUrlInput] = useState("");
+  const [submissionLoading, setSubmissionLoading] = useState(false);
+  const [sessionLoading, setSessionLoading] = useState(false);
+  const [voteError, setVoteError] = useState<string | null>(null);
+
+  const loadIdentity = useCallback(() => {
+    const stored = getIdentity(normalizedCode);
+    if (stored) {
+      setIdentity(stored);
+    }
+  }, [normalizedCode]);
+
+  const fetchCoffeeBar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/coffee-bars/${normalizedCode}`);
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error("We couldn't find this coffee bar. Check the code and try again.");
+        }
+
+        const payload = await response.json().catch(() => null);
+        throw new Error((payload && (payload.detail ?? payload.title)) || "Unable to load this coffee bar.");
+      }
+
+      const data = (await response.json()) as CoffeeBarResource;
+      setCoffeeBar(data);
+      setLoading(false);
+      return data;
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Unable to load this coffee bar.");
+      setLoading(false);
+      return null;
+    }
+  }, [normalizedCode]);
+
+  useEffect(() => {
+    loadIdentity();
+  }, [loadIdentity]);
+
+  useEffect(() => {
+    fetchCoffeeBar();
+  }, [fetchCoffeeBar]);
+
+  useEffect(() => {
+    if (!coffeeBar || !identity) {
+      return;
+    }
+
+    const stillPresent = coffeeBar.hipsters.some((hipster) => hipster.id === identity.hipsterId);
+    if (!stillPresent) {
+      removeIdentity(coffeeBar.code);
+      setIdentity(null);
+    }
+  }, [coffeeBar, identity]);
+
+  const ingredientById = useMemo(() => {
+    if (!coffeeBar) {
+      return new Map<string, IngredientResource>();
+    }
+
+    return new Map(coffeeBar.ingredients.map((ingredient) => [ingredient.id, ingredient] as const));
+  }, [coffeeBar]);
+
+  const submissionCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (!coffeeBar) {
+      return counts;
+    }
+
+    for (const submission of coffeeBar.submissions) {
+      counts[submission.hipsterId] = (counts[submission.hipsterId] ?? 0) + 1;
+    }
+
+    return counts;
+  }, [coffeeBar]);
+
+  const availableIngredients = useMemo(() => {
+    if (!coffeeBar) {
+      return 0;
+    }
+
+    return coffeeBar.ingredients.filter((ingredient) => !ingredient.isConsumed).length;
+  }, [coffeeBar]);
+
+  const activeCycle = useMemo(() => {
+    if (!sessionState) {
+      return null;
+    }
+
+    const cycles = sessionState.session.cycles;
+    if (!cycles.length) {
+      return null;
+    }
+
+    return cycles.find((cycle) => cycle.isActive) ?? cycles[cycles.length - 1];
+  }, [sessionState]);
+
+  const totalVotesNeeded = coffeeBar?.hipsters.length ?? 0;
+  const votesCast = activeCycle?.votes.length ?? 0;
+  const hasIdentity = Boolean(identity);
+  const alreadyVoted = Boolean(
+    identity && activeCycle?.votes.some((vote) => vote.voterHipsterId === identity.hipsterId),
+  );
+
+  const shareLink = useMemo(() => {
+    if (!coffeeBar || typeof window === "undefined") {
+      return "";
+    }
+
+    return `${window.location.origin}/coffee-bars/${coffeeBar.code}`;
+  }, [coffeeBar]);
+
+  const handleJoin = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const trimmed = joinUsername.trim();
+      if (!trimmed) {
+        setJoinError("Please choose a username to join the bar.");
+        return;
+      }
+
+      setJoinLoading(true);
+      setJoinError(null);
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/coffee-bars/${normalizedCode}/hipsters`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: trimmed }),
+        });
+
+        const payload = await response.json();
+        if (!response.ok) {
+          setJoinError((payload && (payload.detail ?? payload.title)) || "We couldn't join that coffee bar.");
+          return;
+        }
+
+        const joined = payload as JoinCoffeeBarResponse;
+        setCoffeeBar(joined.coffeeBar);
+        saveIdentity({
+          coffeeBarId: joined.coffeeBar.id,
+          coffeeBarCode: joined.coffeeBar.code,
+          hipsterId: joined.hipster.id,
+          username: joined.hipster.username,
+        });
+        setIdentity({
+          coffeeBarId: joined.coffeeBar.id,
+          coffeeBarCode: joined.coffeeBar.code,
+          hipsterId: joined.hipster.id,
+          username: joined.hipster.username,
+        });
+        setJoinUsername("");
+      } catch (err) {
+        console.error(err);
+        setJoinError("Something went wrong while joining. Please try again.");
+      } finally {
+        setJoinLoading(false);
+      }
+    },
+    [joinUsername, normalizedCode],
+  );
+
+  const handleSubmitIngredient = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!identity) {
+        return;
+      }
+
+      const trimmed = urlInput.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      setSubmissionLoading(true);
+      setVoteError(null);
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/coffee-bars/${normalizedCode}/ingredients`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hipsterId: identity.hipsterId, url: trimmed }),
+        });
+
+        const payload = await response.json();
+        if (!response.ok) {
+          setVoteError((payload && (payload.detail ?? payload.title)) || "We couldn't submit that URL.");
+          return;
+        }
+
+        const submission = payload as SubmitIngredientResponse;
+        setCoffeeBar(submission.coffeeBar);
+        setSessionState((current) => (current ? { ...current, coffeeBar: submission.coffeeBar } : current));
+        setUrlInput("");
+      } catch (err) {
+        console.error(err);
+        setVoteError("Something went wrong while submitting. Please try again.");
+      } finally {
+        setSubmissionLoading(false);
+      }
+    },
+    [identity, normalizedCode, urlInput],
+  );
+
+  const handleRemoveSubmission = useCallback(
+    async (submissionId: string) => {
+      if (!identity) {
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `${API_BASE_URL}/coffee-bars/${normalizedCode}/submissions/${submissionId}?hipsterId=${identity.hipsterId}`,
+          {
+            method: "DELETE",
+          },
+        );
+
+        if (response.status === 404) {
+          setVoteError("We couldn't find that submission anymore.");
+          await fetchCoffeeBar();
+          return;
+        }
+
+        const payload = await response.json().catch(() => null);
+        if (!response.ok) {
+          setVoteError((payload && (payload.detail ?? payload.title)) || "We couldn't remove that submission.");
+          return;
+        }
+
+        const updated = payload as CoffeeBarResource;
+        setCoffeeBar(updated);
+        setSessionState((current) => (current ? { ...current, coffeeBar: updated } : current));
+      } catch (err) {
+        console.error(err);
+        setVoteError("Something went wrong while removing the URL.");
+      }
+    },
+    [identity, normalizedCode, fetchCoffeeBar],
+  );
+
+  const refreshSession = useCallback(
+    async (sessionId: string) => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/coffee-bars/${normalizedCode}/sessions/${sessionId}`);
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as SessionStateResource;
+        setCoffeeBar(payload.coffeeBar);
+        setSessionState(payload);
+      } catch (err) {
+        console.error(err);
+      }
+    },
+    [normalizedCode],
+  );
+
+  useEffect(() => {
+    if (!sessionState) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      refreshSession(sessionState.session.id);
+    }, 5000);
+
+    return () => window.clearInterval(interval);
+  }, [sessionState, refreshSession]);
+
+  const handleStartSession = useCallback(async () => {
+    if (!coffeeBar) {
+      return;
+    }
+
+    setSessionLoading(true);
+    setVoteError(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/coffee-bars/${normalizedCode}/sessions`, {
+        method: "POST",
+      });
+
+      const payload = await response.json();
+      if (!response.ok) {
+        setVoteError((payload && (payload.detail ?? payload.title)) || "We couldn't start the session.");
+        return;
+      }
+
+      const state = payload as SessionStateResource;
+      setCoffeeBar(state.coffeeBar);
+      setSessionState(state);
+    } catch (err) {
+      console.error(err);
+      setVoteError("Something went wrong while starting the session.");
+    } finally {
+      setSessionLoading(false);
+    }
+  }, [coffeeBar, normalizedCode]);
+
+  const handleCastVote = useCallback(
+    async (targetHipsterId: string) => {
+      if (!identity || !activeCycle) {
+        return;
+      }
+
+      setVoteError(null);
+
+      try {
+        const response = await fetch(
+          `${API_BASE_URL}/coffee-bars/${normalizedCode}/sessions/${activeCycle.sessionId}/cycles/${activeCycle.id}/votes`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ voterHipsterId: identity.hipsterId, targetHipsterId }),
+          },
+        );
+
+        const payload = await response.json();
+        if (!response.ok) {
+          setVoteError((payload && (payload.detail ?? payload.title)) || "We couldn't cast that vote.");
+          return;
+        }
+
+        const state = payload as SessionStateResource;
+        setCoffeeBar(state.coffeeBar);
+        setSessionState(state);
+      } catch (err) {
+        console.error(err);
+        setVoteError("Something went wrong while casting your vote.");
+      }
+    },
+    [identity, activeCycle, normalizedCode],
+  );
+
+  const mySubmissions = useMemo(() => {
+    if (!identity || !coffeeBar) {
+      return [] as { submission: SubmissionResource; ingredient?: IngredientResource }[];
+    }
+
+    return coffeeBar.submissions
+      .filter((submission) => submission.hipsterId === identity.hipsterId)
+      .map((submission) => ({ submission, ingredient: ingredientById.get(submission.ingredientId) }));
+  }, [coffeeBar, identity, ingredientById]);
+
+  return (
+    <div className={styles.page}>
+      {loading && !coffeeBar ? (
+        <div className={styles.loading}>Loading your coffee bar…</div>
+      ) : error ? (
+        <div className={styles.error}>{error}</div>
+      ) : coffeeBar ? (
+        <>
+          <header className={styles.header}>
+            <div className={styles.headerTop}>Coffee Bar · {coffeeBar.code}</div>
+            <h1 className={styles.title}>{coffeeBar.theme}</h1>
+            <p className={styles.shareHint}>
+              Share this link with your crew: {" "}
+              {shareLink ? (
+                <a className={styles.shareAnchor} href={shareLink}>
+                  {shareLink}
+                </a>
+              ) : (
+                "Copy the URL"
+              )}
+            </p>
+            <p className={styles.policy}>
+              Policy: <strong>{coffeeBar.submissionPolicy === "LockOnFirstBrew" ? "Lock on first brew" : "Always open"}</strong>
+              {" · "}Max ingredients per hipster: <strong>{coffeeBar.defaultMaxIngredientsPerHipster}</strong>
+            </p>
+          </header>
+
+          <div className={styles.layout}>
+            <aside className={styles.sidebar}>
+              <section className={styles.card}>
+                <h2 className={styles.cardTitle}>Hipsters in the bar</h2>
+                <ul className={styles.hipsterList}>
+                  {coffeeBar.hipsters.length === 0 && <li>No hipsters yet. Be the first to join!</li>}
+                  {coffeeBar.hipsters.map((hipster) => (
+                    <li key={hipster.id} className={identity?.hipsterId === hipster.id ? styles.me : undefined}>
+                      <span className={styles.hipsterName}>{hipster.username}</span>
+                      <span className={styles.hipsterCount}>{submissionCounts[hipster.id] ?? 0} urls</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section className={styles.card}>
+                <h2 className={styles.cardTitle}>Session</h2>
+                <p className={styles.sessionStatus}>
+                  {sessionState ? `Session started ${new Date(sessionState.session.startedAt).toLocaleTimeString()}` : "No active session yet."}
+                </p>
+                <button
+                  className={styles.primaryButton}
+                  type="button"
+                  onClick={handleStartSession}
+                  disabled={sessionLoading || availableIngredients === 0 || !hasIdentity}
+                >
+                  {sessionLoading ? "Starting…" : sessionState ? "Restart session" : "Start session"}
+                </button>
+                <p className={styles.sessionHint}>
+                  {availableIngredients === 0
+                    ? "Add more ingredients before brewing."
+                    : `${availableIngredients} ingredient${availableIngredients === 1 ? "" : "s"} ready to brew.`}
+                </p>
+                {!hasIdentity && <p className={styles.sessionHint}>Join the bar to control the brew.</p>}
+              </section>
+
+              {!hasIdentity && (
+                <section className={styles.card}>
+                  <h2 className={styles.cardTitle}>Join this bar</h2>
+                  <form className={styles.joinForm} onSubmit={handleJoin}>
+                    <input
+                      className={styles.input}
+                      value={joinUsername}
+                      onChange={(event) => setJoinUsername(event.target.value)}
+                      placeholder="Your username"
+                      required
+                      minLength={3}
+                      maxLength={20}
+                      disabled={joinLoading}
+                    />
+                    <button className={styles.primaryButton} type="submit" disabled={joinLoading}>
+                      {joinLoading ? "Joining…" : "Join"}
+                    </button>
+                  </form>
+                  {joinError && <div className={styles.inlineError}>{joinError}</div>}
+                </section>
+              )}
+
+              {hasIdentity && identity && (
+                <section className={styles.card}>
+                  <h2 className={styles.cardTitle}>You're in</h2>
+                  <p className={styles.identityLine}>
+                    Signed in as <strong>{identity.username}</strong>
+                  </p>
+                </section>
+              )}
+            </aside>
+
+            <main className={styles.main}>
+              {hasIdentity ? (
+                <section className={styles.card}>
+                  <h2 className={styles.cardTitle}>Submit a new ingredient</h2>
+                  <form className={styles.submitForm} onSubmit={handleSubmitIngredient}>
+                    <input
+                      className={styles.input}
+                      value={urlInput}
+                      onChange={(event) => setUrlInput(event.target.value)}
+                      placeholder="Paste a YouTube URL"
+                      required
+                      disabled={submissionLoading || coffeeBar.submissionsLocked}
+                    />
+                    <button className={styles.primaryButton} type="submit" disabled={submissionLoading || coffeeBar.submissionsLocked}>
+                      {submissionLoading ? "Submitting…" : "Submit"}
+                    </button>
+                  </form>
+                  {coffeeBar.submissionsLocked && (
+                    <p className={styles.sessionHint}>Submissions are locked while brewing.</p>
+                  )}
+                </section>
+              ) : (
+                <section className={styles.card}>
+                  <h2 className={styles.cardTitle}>Ready to brew?</h2>
+                  <p className={styles.sessionHint}>Join the bar from the left column to start submitting your favourite tracks.</p>
+                </section>
+              )}
+
+              {hasIdentity && (
+                <section className={styles.card}>
+                  <h2 className={styles.cardTitle}>Your submissions</h2>
+                  {mySubmissions.length === 0 ? (
+                    <p className={styles.sessionHint}>You haven't queued any videos yet.</p>
+                  ) : (
+                    <ul className={styles.submissionList}>
+                      {mySubmissions.map(({ submission, ingredient }) => (
+                        <li key={submission.id}>
+                          <div className={styles.submissionRow}>
+                            <span>
+                              {ingredient ? (
+                                <a
+                                  className={styles.shareAnchor}
+                                  href={`https://youtu.be/${ingredient.videoId}`}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  https://youtu.be/{ingredient.videoId}
+                                </a>
+                              ) : (
+                                "Unknown video"
+                              )}
+                            </span>
+                            <button
+                              type="button"
+                              className={styles.secondaryButton}
+                              onClick={() => handleRemoveSubmission(submission.id)}
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              )}
+
+              <section className={styles.card}>
+                <h2 className={styles.cardTitle}>Now playing</h2>
+                {sessionState && activeCycle ? (
+                  <div className={styles.playerArea}>
+                    <div className={styles.playerWrapper}>
+                      <iframe
+                        className={styles.player}
+                        src={`https://www.youtube.com/embed/${activeCycle.videoId}?autoplay=1`}
+                        title="Coffee Talk Video"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowFullScreen
+                      />
+                    </div>
+                    <aside className={styles.voteSidebar}>
+                      <div className={styles.voteHeader}>Who's the curator?</div>
+                      <div className={styles.voteSummary}>
+                        Votes: {votesCast}/{totalVotesNeeded}
+                      </div>
+                      {hasIdentity ? (
+                        <ul className={styles.voteList}>
+                          {coffeeBar.hipsters.map((hipster) => (
+                            <li key={hipster.id}>
+                              <button
+                                type="button"
+                                className={styles.voteButton}
+                                disabled={hipster.id === identity.hipsterId || alreadyVoted}
+                                onClick={() => handleCastVote(hipster.id)}
+                              >
+                                {hipster.username}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className={styles.sessionHint}>Join the bar to cast your vote.</p>
+                      )}
+                    </aside>
+                  </div>
+                ) : (
+                  <p className={styles.sessionHint}>Start a session to spin up the first video.</p>
+                )}
+              </section>
+
+              {voteError && <div className={styles.inlineError}>{voteError}</div>}
+            </main>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/page.tsx
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/page.tsx
@@ -1,0 +1,10 @@
+import { CoffeeBarClient } from "./CoffeeBarClient";
+
+type CoffeeBarPageProps = {
+  params: Promise<{ code: string }>;
+};
+
+export default async function CoffeeBarPage({ params }: CoffeeBarPageProps) {
+  const { code } = await params;
+  return <CoffeeBarClient code={code} />;
+}

--- a/src/CoffeeTalk.Web/app/lib/identity.ts
+++ b/src/CoffeeTalk.Web/app/lib/identity.ts
@@ -1,0 +1,56 @@
+const STORAGE_KEY = "coffee-talk:identities";
+
+export type HipsterIdentity = {
+  coffeeBarId: string;
+  coffeeBarCode: string;
+  hipsterId: string;
+  username: string;
+};
+
+type IdentityDictionary = Record<string, HipsterIdentity>;
+
+function readAll(): IdentityDictionary {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as IdentityDictionary;
+    return parsed ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(values: IdentityDictionary) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
+}
+
+export function saveIdentity(identity: HipsterIdentity) {
+  const existing = readAll();
+  existing[identity.coffeeBarCode.toUpperCase()] = identity;
+  writeAll(existing);
+}
+
+export function getIdentity(coffeeBarCode: string): HipsterIdentity | undefined {
+  const existing = readAll();
+  return existing[coffeeBarCode.toUpperCase()];
+}
+
+export function removeIdentity(coffeeBarCode: string) {
+  const existing = readAll();
+  const normalized = coffeeBarCode.toUpperCase();
+  if (existing[normalized]) {
+    delete existing[normalized];
+    writeAll(existing);
+  }
+}

--- a/src/CoffeeTalk.Web/app/page.module.css
+++ b/src/CoffeeTalk.Web/app/page.module.css
@@ -136,6 +136,26 @@
   font-weight: 700;
 }
 
+.shareLink {
+  margin-top: 0.75rem;
+}
+
+.shareAnchor {
+  color: #8b5e3c;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.shareAnchor:hover {
+  text-decoration: underline;
+}
+
+.identityHint {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: #5a3b33;
+}
+
 .error {
   color: #b42318;
   font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- auto-join bar creators, expose submission removal, brew session, and voting endpoints, and extend coffee bar contracts with sessions
- add a random next-ingredient selector and domain hooks to remove submissions safely
- build a coffee bar page that shows roster, submission quotas, submission management, and a session/voting experience with persisted identities and share links

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e50b448608832bb5e496bb9f832b1d