### PR TITLE
Add manual cycle controls and split cycle view

### DIFF
--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CoffeeTalk.Domain.BrewSessions;
 using CoffeeTalk.Domain.CoffeeBars;
 
@@ -112,5 +113,16 @@ public static class CoffeeBarContractsMapper
         ArgumentNullException.ThrowIfNull(session);
 
         return new SessionStateResource(ToResource(coffeeBar), ToResource(session, coffeeBar));
+    }
+
+    public static RevealResultResource ToResource(RevealResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var tally = result.Tally.ToDictionary(pair => pair.Key, pair => pair.Value);
+        var submitters = result.CorrectSubmitterIds.ToList();
+        var guessers = result.CorrectGuessers.ToList();
+
+        return new RevealResultResource(result.CycleId, tally, submitters, guessers);
     }
 }

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/RevealCycleRequest.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/RevealCycleRequest.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record RevealCycleRequest(Guid HipsterId);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/RevealCycleResponse.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/RevealCycleResponse.cs
@@ -1,0 +1,3 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record RevealCycleResponse(SessionStateResource Session, RevealResultResource Reveal);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/RevealResultResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/RevealResultResource.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record RevealResultResource(
+    Guid CycleId,
+    IReadOnlyDictionary<Guid, int> Tally,
+    IReadOnlyCollection<Guid> CorrectSubmitterIds,
+    IReadOnlyCollection<Guid> CorrectGuessers);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/StartNextCycleRequest.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/StartNextCycleRequest.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record StartNextCycleRequest(Guid HipsterId);

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
@@ -64,6 +64,34 @@
   color: #6f4a3f;
 }
 
+.viewSwitcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.viewButton {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: rgba(139, 94, 60, 0.16);
+  color: #5a3b33;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.viewButton:hover {
+  background: rgba(139, 94, 60, 0.25);
+}
+
+.viewButtonActive {
+  background: #8b5e3c;
+  color: #fffaf5;
+}
+
 .layout {
   display: flex;
   flex-direction: column;
@@ -245,6 +273,47 @@
   background: rgba(139, 94, 60, 0.12);
 }
 
+.secondaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cycleView {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cycleColumns {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .cycleColumns {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .cycleColumns > section {
+    flex: 1;
+  }
+}
+
+.cycleButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cycleAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 12rem;
+}
+
 .playerArea {
   display: flex;
   flex-direction: column;
@@ -323,4 +392,37 @@
 .voteButton:not(:disabled):hover {
   transform: translateY(-1px);
   box-shadow: 0 8px 18px rgba(75, 46, 46, 0.18);
+}
+
+.revealSummary {
+  background: rgba(139, 94, 60, 0.12);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.tallyList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tallyRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(139, 94, 60, 0.1);
+  padding: 0.6rem 0.9rem;
+  border-radius: 10px;
+}
+
+.tallyCount {
+  font-weight: 700;
+  color: #5a3b33;
 }

--- a/src/CoffeeTalk.Web/app/components/CreateCoffeeBarForm.tsx
+++ b/src/CoffeeTalk.Web/app/components/CreateCoffeeBarForm.tsx
@@ -205,7 +205,7 @@ export function CreateCoffeeBarForm() {
             </div>
           )}
           <div className={styles.identityHint}>
-            You're in! We saved your handle (<strong>{result.hipster.username}</strong>) so you can dive back into the bar instantly.
+            You’re in! We saved your handle (<strong>{result.hipster.username}</strong>) so you can dive back into the bar instantly.
           </div>
         </div>
       )}

--- a/src/CoffeeTalk.Web/app/components/JoinCoffeeBarForm.tsx
+++ b/src/CoffeeTalk.Web/app/components/JoinCoffeeBarForm.tsx
@@ -168,7 +168,7 @@ export function JoinCoffeeBarForm() {
             </div>
           )}
           <div className={styles.identityHint}>
-            We've saved your spot so you can hop straight into the bar next time.
+            We’ve saved your spot so you can hop straight into the bar next time.
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add API contracts and endpoints so hipsters can reveal a cycle and start the next brew manually
- surface reveal results in the mapper and cover the new workflow with an integration test
- split the coffee bar client into management and cycle views with updated controls and styling

## Testing
- dotnet test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e51bbf6020832b848fd95807f7199f