### PR TITLE
Add SignalR synchronization for coffee bar sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,4 +29,5 @@ These guidelines apply to the entire repository unless a more specific `AGENTS.m
 - After installation, ensure the current session can find the SDK by exporting the path: `export PATH="$HOME/.dotnet:$PATH"`. Persist the change in your shell profile if you need the SDK in new sessions.
 - Always run `dotnet build` and `dotnet test` (and relevant frontend test/build commands when frontend code is touched) before completing work.
 - Ensure automated tests cover key business rules described in the PRD, especially around the domain model.
+- When updating the Next.js client, run `CI=1 npm run lint` and `CI=1 npm run build` to verify the bundle compiles cleanly.
 

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/BrewSessionResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/BrewSessionResource.cs
@@ -3,4 +3,5 @@ namespace CoffeeTalk.Api.Contracts.CoffeeBars;
 public sealed record BrewSessionResource(
     Guid Id,
     DateTimeOffset StartedAt,
+    DateTimeOffset? EndedAt,
     IReadOnlyList<BrewCycleResource> Cycles);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
@@ -25,6 +25,11 @@ public static class CoffeeBarContractsMapper
             .Select(ToResource)
             .ToList();
 
+        var activeSessionId = coffeeBar.Sessions
+            .OrderByDescending(session => session.StartedAt)
+            .FirstOrDefault(session => session.IsActive)
+            ?.Id;
+
         return new CoffeeBarResource(
             coffeeBar.Id,
             coffeeBar.Code.Value,
@@ -33,6 +38,7 @@ public static class CoffeeBarContractsMapper
             coffeeBar.SubmissionPolicy,
             coffeeBar.SubmissionsLocked,
             coffeeBar.IsClosed,
+            activeSessionId,
             hipsters,
             ingredients,
             submissions);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarContractsMapper.cs
@@ -72,10 +72,14 @@ public static class CoffeeBarContractsMapper
 
         var cycles = session.Cycles
             .OrderBy(cycle => cycle.StartedAt)
-            .Select(cycle => ToResource(cycle, ingredientLookup[cycle.IngredientId]))
+            .Select(cycle => ingredientLookup.TryGetValue(cycle.IngredientId, out var ingredient)
+                ? ToResource(cycle, ingredient)
+                : null)
+            .Where(resource => resource is not null)
+            .Select(resource => resource!)
             .ToList();
 
-        return new BrewSessionResource(session.Id, session.StartedAt, cycles);
+        return new BrewSessionResource(session.Id, session.StartedAt, session.EndedAt, cycles);
     }
 
     public static BrewCycleResource ToResource(BrewCycle cycle, Ingredient ingredient)

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarResource.cs
@@ -11,6 +11,7 @@ public sealed record CoffeeBarResource(
     SubmissionPolicy SubmissionPolicy,
     bool SubmissionsLocked,
     bool IsClosed,
+    Guid? ActiveSessionId,
     IReadOnlyList<HipsterResource> Hipsters,
     IReadOnlyList<IngredientResource> Ingredients,
     IReadOnlyList<SubmissionResource> Submissions);

--- a/src/CoffeeTalk.Api/Endpoints/CoffeeBarEndpoints.cs
+++ b/src/CoffeeTalk.Api/Endpoints/CoffeeBarEndpoints.cs
@@ -259,10 +259,17 @@ public static class CoffeeBarEndpoints
             await repository.UpdateAsync(coffeeBar, cancellationToken).ConfigureAwait(false);
 
             var response = CoffeeBarContractsMapper.ToSessionStateResource(coffeeBar, session);
+            var group = CoffeeBarHub.GetGroupName(response.CoffeeBar.Code);
 
             await hubContext
                 .Clients
-                .Group(CoffeeBarHub.GetGroupName(response.CoffeeBar.Code))
+                .Group(group)
+                .CoffeeBarUpdated(response.CoffeeBar)
+                .ConfigureAwait(false);
+
+            await hubContext
+                .Clients
+                .Group(group)
                 .SessionUpdated(response)
                 .ConfigureAwait(false);
 

--- a/src/CoffeeTalk.Api/Hubs/CoffeeBarHub.cs
+++ b/src/CoffeeTalk.Api/Hubs/CoffeeBarHub.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using CoffeeTalk.Api.Contracts.CoffeeBars;
+using CoffeeTalk.Domain.BrewSessions;
+using CoffeeTalk.Domain.CoffeeBars;
+using CoffeeTalk.Infrastructure.Data.Repositories;
+using Microsoft.AspNetCore.SignalR;
+
+namespace CoffeeTalk.Api.Hubs;
+
+public interface ICoffeeBarClient
+{
+    Task CoffeeBarUpdated(CoffeeBarResource coffeeBar);
+
+    Task SessionUpdated(SessionStateResource session);
+
+    Task CycleRevealed(RevealCycleResponse response);
+}
+
+public sealed class CoffeeBarHub(ICoffeeBarRepository repository) : Hub<ICoffeeBarClient>
+{
+    private readonly ICoffeeBarRepository _repository = repository;
+
+    public static string GetGroupName(string code) => $"coffee-bar:{NormalizeCode(code)}";
+
+    public async Task JoinCoffeeBar(string code, CancellationToken cancellationToken = default)
+    {
+        var normalized = NormalizeCode(code);
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupName(normalized), cancellationToken)
+            .ConfigureAwait(false);
+
+        var coffeeBar = await _repository.GetByCodeAsync(normalized, cancellationToken).ConfigureAwait(false);
+        if (coffeeBar is null)
+        {
+            return;
+        }
+
+        var coffeeBarResource = CoffeeBarContractsMapper.ToResource(coffeeBar);
+        await Clients.Caller.CoffeeBarUpdated(coffeeBarResource).ConfigureAwait(false);
+
+        var latestSession = coffeeBar.Sessions
+            .OrderByDescending(session => session.StartedAt)
+            .FirstOrDefault();
+
+        if (latestSession is null)
+        {
+            return;
+        }
+
+        var sessionResource = CoffeeBarContractsMapper.ToSessionStateResource(coffeeBar, latestSession);
+        await Clients.Caller.SessionUpdated(sessionResource).ConfigureAwait(false);
+
+        var latestCycle = latestSession.Cycles
+            .OrderBy(cycle => cycle.StartedAt)
+            .LastOrDefault();
+
+        if (latestCycle is null || latestCycle.IsActive)
+        {
+            return;
+        }
+
+        var reveal = CreateRevealResource(coffeeBar, latestCycle);
+        await Clients.Caller.CycleRevealed(new RevealCycleResponse(sessionResource, reveal)).ConfigureAwait(false);
+    }
+
+    public Task LeaveCoffeeBar(string code, CancellationToken cancellationToken = default) =>
+        Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroupName(code), cancellationToken);
+
+    private static string NormalizeCode(string code)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        return code.Trim().ToUpperInvariant();
+    }
+
+    private static RevealResultResource CreateRevealResource(CoffeeBar coffeeBar, BrewCycle cycle)
+    {
+        var ingredient = coffeeBar.Ingredients.First(ingredient => ingredient.Id == cycle.IngredientId);
+
+        var tally = cycle.Votes
+            .GroupBy(vote => vote.TargetHipsterId)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var correctGuessers = cycle.Votes
+            .Where(vote => vote.IsCorrect == true)
+            .Select(vote => vote.VoterHipsterId)
+            .ToList();
+
+        return new RevealResultResource(
+            cycle.Id,
+            tally,
+            ingredient.SubmitterIds.ToList(),
+            correctGuessers);
+    }
+}

--- a/src/CoffeeTalk.Api/Hubs/CoffeeBarHub.cs
+++ b/src/CoffeeTalk.Api/Hubs/CoffeeBarHub.cs
@@ -63,8 +63,20 @@ public sealed class CoffeeBarHub(ICoffeeBarRepository repository, ILogger<Coffee
             return;
         }
 
-        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupName(normalized), cancellationToken)
-            .ConfigureAwait(false);
+        try
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupName(normalized), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to add connection {ConnectionId} to coffee bar group {Code}.",
+                Context.ConnectionId,
+                normalized);
+            return;
+        }
 
         try
         {

--- a/src/CoffeeTalk.Api/Program.cs
+++ b/src/CoffeeTalk.Api/Program.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CoffeeTalk.Api.Endpoints;
+using CoffeeTalk.Api.Hubs;
 using CoffeeTalk.Api.Services;
 using CoffeeTalk.Domain.CoffeeBars;
 using CoffeeTalk.Infrastructure.Data;
@@ -23,7 +24,8 @@ builder.Services.AddCors(options =>
                 "http://localhost:3000",
                 "https://localhost:3000")
             .AllowAnyHeader()
-            .AllowAnyMethod();
+            .AllowAnyMethod()
+            .AllowCredentials();
     });
 });
 
@@ -49,6 +51,7 @@ builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IBrewSessionSummaryProvider, InMemoryBrewSessionSummaryProvider>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSignalR();
 
 var app = builder.Build();
 
@@ -63,5 +66,6 @@ app.UseCors(FrontendCorsPolicyName);
 app.MapDefaultEndpoints();
 app.MapCoffeeBarEndpoints();
 app.MapBrewSessionEndpoints();
+app.MapHub<CoffeeBarHub>("/hubs/coffee-bar");
 
 app.Run();

--- a/src/CoffeeTalk.Domain/CoffeeBars/CoffeeBar.cs
+++ b/src/CoffeeTalk.Domain/CoffeeBars/CoffeeBar.cs
@@ -158,6 +158,11 @@ public sealed class CoffeeBar
             throw new DomainException("Coffee bar is closed because all ingredients have been consumed.");
         }
 
+        if (_sessions.Any(session => session.IsActive))
+        {
+            throw new DomainException("A session is already active for this coffee bar.");
+        }
+
         if (_sessions.Any(session => session.Id == sessionId))
         {
             throw new DomainException("A session with the same identifier already exists.");
@@ -205,6 +210,24 @@ public sealed class CoffeeBar
 
         var cycle = session.StartCycle(cycleId, selected.Id, startedAt);
         return cycle;
+    }
+
+    public BrewSession EndSession(Guid sessionId, DateTimeOffset endedAt)
+    {
+        if (sessionId == Guid.Empty)
+        {
+            throw new DomainException("Session identifier cannot be empty.");
+        }
+
+        var session = GetSession(sessionId);
+        session.End(endedAt);
+
+        if (SubmissionPolicy == SubmissionPolicy.LockOnFirstBrew)
+        {
+            _submissionsLocked = false;
+        }
+
+        return session;
     }
 
     public void RemoveSubmission(Guid hipsterId, Guid submissionId)

--- a/src/CoffeeTalk.Infrastructure/Data/Entities/BrewSessionEntity.cs
+++ b/src/CoffeeTalk.Infrastructure/Data/Entities/BrewSessionEntity.cs
@@ -8,6 +8,8 @@ public sealed class BrewSessionEntity
 
     public DateTimeOffset StartedAt { get; set; }
 
+    public DateTimeOffset? EndedAt { get; set; }
+
     public CoffeeBarEntity? CoffeeBar { get; set; }
 
     public ICollection<BrewCycleEntity> Cycles { get; set; } = new List<BrewCycleEntity>();

--- a/src/CoffeeTalk.Infrastructure/Data/Mappings/BrewSessionMapper.cs
+++ b/src/CoffeeTalk.Infrastructure/Data/Mappings/BrewSessionMapper.cs
@@ -15,7 +15,8 @@ internal static class BrewSessionMapper
         {
             Id = session.Id,
             CoffeeBarId = session.CoffeeBarId,
-            StartedAt = session.StartedAt
+            StartedAt = session.StartedAt,
+            EndedAt = session.EndedAt
         };
 
         entity.Cycles = session.Cycles
@@ -29,6 +30,6 @@ internal static class BrewSessionMapper
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return BrewSession.FromState(entity.Id, entity.CoffeeBarId, entity.StartedAt, cycles);
+        return BrewSession.FromState(entity.Id, entity.CoffeeBarId, entity.StartedAt, entity.EndedAt, cycles);
     }
 }

--- a/src/CoffeeTalk.Infrastructure/Data/Migrations/20251007095540_InitialCreate.cs
+++ b/src/CoffeeTalk.Infrastructure/Data/Migrations/20251007095540_InitialCreate.cs
@@ -33,7 +33,8 @@ namespace CoffeeTalk.Infrastructure.Data.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     CoffeeBarId = table.Column<Guid>(type: "uuid", nullable: false),
-                    StartedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                    StartedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    EndedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/src/CoffeeTalk.Infrastructure/Data/Migrations/CoffeeTalkDbContextModelSnapshot.cs
+++ b/src/CoffeeTalk.Infrastructure/Data/Migrations/CoffeeTalkDbContextModelSnapshot.cs
@@ -61,6 +61,9 @@ namespace CoffeeTalk.Infrastructure.Data.Migrations
                     b.Property<DateTimeOffset>("StartedAt")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<DateTimeOffset?>("EndedAt")
+                        .HasColumnType("timestamp with time zone");
+
                     b.HasKey("Id");
 
                     b.HasIndex("CoffeeBarId");

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
@@ -344,6 +344,18 @@
   border: none;
 }
 
+.playerPlaceholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-weight: 600;
+  color: rgba(255, 250, 245, 0.85);
+  padding: 1rem;
+}
+
 .voteSidebar {
   flex: 1;
   background: rgba(139, 94, 60, 0.08);

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.tsx
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { HubConnection } from "@microsoft/signalr";
-import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { FormEvent, memo, useCallback, useEffect, useMemo, useState } from "react";
 import styles from "./CoffeeBarClient.module.css";
 import { getIdentity, removeIdentity, saveIdentity, type HipsterIdentity } from "../../lib/identity";
 
@@ -101,6 +101,29 @@ type CoffeeBarClientProps = {
   code: string;
 };
 
+type YouTubeEmbedProps = {
+  videoId: string;
+  title: string;
+  className?: string;
+};
+
+const YouTubeEmbed = memo(function YouTubeEmbed({ videoId, title, className }: YouTubeEmbedProps) {
+  const src = useMemo(
+    () => `https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`,
+    [videoId],
+  );
+
+  return (
+    <iframe
+      className={className}
+      src={src}
+      title={title}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowFullScreen
+    />
+  );
+});
+
 export function CoffeeBarClient({ code }: CoffeeBarClientProps) {
   const normalizedCode = code.toUpperCase();
 
@@ -124,6 +147,7 @@ export function CoffeeBarClient({ code }: CoffeeBarClientProps) {
   const [lastCycleId, setLastCycleId] = useState<string | null>(null);
   const [realtimeConnected, setRealtimeConnected] = useState(false);
   const [playerCycle, setPlayerCycle] = useState<BrewCycleResource | null>(null);
+  const [isClient, setIsClient] = useState(false);
 
   const loadIdentity = useCallback(() => {
     const stored = getIdentity(normalizedCode);
@@ -180,6 +204,10 @@ export function CoffeeBarClient({ code }: CoffeeBarClientProps) {
   useEffect(() => {
     fetchCoffeeBar();
   }, [fetchCoffeeBar]);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     if (!API_BASE_URL) {
@@ -1058,16 +1086,15 @@ export function CoffeeBarClient({ code }: CoffeeBarClientProps) {
                 {sessionState && cycleForPlayer ? (
                   <div className={styles.playerArea}>
                     <div className={styles.playerWrapper}>
-                      <iframe
-                        key={cycleForPlayer.id}
-                        className={styles.player}
-                        src={`https://www.youtube.com/embed/${cycleForPlayer.videoId}?autoplay=${
-                          activeCycle && activeCycle.id === cycleForPlayer.id ? 1 : 0
-                        }`}
-                        title="Coffee Talk Video"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowFullScreen
-                      />
+                      {isClient ? (
+                        <YouTubeEmbed
+                          videoId={cycleForPlayer.videoId}
+                          title="Coffee Talk Video"
+                          className={styles.player}
+                        />
+                      ) : (
+                        <div className={styles.playerPlaceholder}>Loading the player…</div>
+                      )}
                     </div>
                     <aside className={styles.voteSidebar}>
                       <div className={styles.voteHeader}>Who’s the curator?</div>

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.tsx
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.tsx
@@ -37,6 +37,7 @@ type CoffeeBarResource = {
   submissionPolicy: SubmissionPolicy;
   submissionsLocked: boolean;
   isClosed: boolean;
+  activeSessionId: string | null;
   hipsters: HipsterResource[];
   ingredients: IngredientResource[];
   submissions: SubmissionResource[];
@@ -603,6 +604,18 @@ export function CoffeeBarClient({ code }: CoffeeBarClientProps) {
     },
     [normalizedCode],
   );
+
+  useEffect(() => {
+    if (!coffeeBar || !coffeeBar.activeSessionId) {
+      return;
+    }
+
+    if (sessionState && sessionState.session.id === coffeeBar.activeSessionId) {
+      return;
+    }
+
+    void refreshSession(coffeeBar.activeSessionId);
+  }, [coffeeBar, refreshSession, sessionState]);
 
   useEffect(() => {
     if (realtimeConnected) {

--- a/src/CoffeeTalk.Web/package.json
+++ b/src/CoffeeTalk.Web/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@microsoft/signalr": "8.0.7",
     "next": "15.5.4",
     "react": "19.2.0",
     "react-dom": "19.2.0"

--- a/tests/CoffeeTalk.Api.Tests/CoffeeBarEndpointsTests.cs
+++ b/tests/CoffeeTalk.Api.Tests/CoffeeBarEndpointsTests.cs
@@ -40,11 +40,13 @@ public sealed class CoffeeBarEndpointsTests
         created.Code.Length.ShouldBe(6);
         created.Code.All(char.IsLetterOrDigit).ShouldBeTrue();
         created.Code.ToUpperInvariant().IndexOfAny("AEIOU".ToCharArray()).ShouldBe(-1);
+        created.ActiveSessionId.ShouldBeNull();
 
         var fetched = await client.GetFromJsonAsync<CoffeeBarResource>($"/coffee-bars/{created.Code}", SerializerOptions);
         fetched.ShouldNotBeNull();
         fetched!.Code.ShouldBe(created.Code);
         fetched.Theme.ShouldBe("Synthwave Showdown");
+        fetched.ActiveSessionId.ShouldBeNull();
     }
 
     [RequiresDockerFact]
@@ -144,6 +146,7 @@ public sealed class CoffeeBarEndpointsTests
         sessionState.ShouldNotBeNull();
 
         var sessionId = sessionState!.Session.Id;
+        sessionState.CoffeeBar.ActiveSessionId.ShouldBe(sessionId);
         var cycle = sessionState.Session.Cycles.ShouldHaveSingleItem();
 
         var voteResponse = await client.PostAsJsonAsync(


### PR DESCRIPTION
## Summary
- add a typed SignalR hub and wire API endpoints to broadcast coffee bar and session changes
- configure the API to host the hub with CORS credentials enabled and expose the new endpoint
- connect the CoffeeBar client to the hub for real-time updates with automatic reconnect and fall back polling, and add the SignalR client package

## Testing
- npm run lint
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e526d8d3d4832ba87e0d92ce30e3b5