### PR TITLE
Add coffee bar leaderboard endpoint and UI

### DIFF
--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarLeaderboardResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/CoffeeBarLeaderboardResource.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record CoffeeBarLeaderboardResource(
+    IReadOnlyList<LeaderboardEntryResource> Overall,
+    IReadOnlyList<SessionLeaderboardResource> Sessions);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/LeaderboardEntryResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/LeaderboardEntryResource.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record LeaderboardEntryResource(
+    Guid HipsterId,
+    string Username,
+    int Score,
+    int Rank,
+    int? PreviousRank,
+    LeaderboardTrend Trend);

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/LeaderboardTrend.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/LeaderboardTrend.cs
@@ -1,0 +1,8 @@
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public enum LeaderboardTrend
+{
+    Stable,
+    Up,
+    Down,
+}

--- a/src/CoffeeTalk.Api/Contracts/CoffeeBars/SessionLeaderboardResource.cs
+++ b/src/CoffeeTalk.Api/Contracts/CoffeeBars/SessionLeaderboardResource.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace CoffeeTalk.Api.Contracts.CoffeeBars;
+
+public sealed record SessionLeaderboardResource(
+    Guid SessionId,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? EndedAt,
+    IReadOnlyList<LeaderboardEntryResource> Entries);

--- a/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
+++ b/src/CoffeeTalk.Web/app/coffee-bars/[code]/CoffeeBarClient.module.css
@@ -559,3 +559,170 @@
   font-weight: 700;
   color: #5a3b33;
 }
+
+.leaderboardView {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.leaderboardHeader {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.leaderboardHint {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: #5a3b33;
+}
+
+.leaderboardControls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.leaderboardLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #6f4a3f;
+}
+
+.leaderboardSelect {
+  border-radius: 999px;
+  border: 1px solid #d3b49f;
+  padding: 0.45rem 1rem;
+  background: #fff;
+  color: #3f2626;
+  font-weight: 600;
+}
+
+.leaderboardTableWrapper {
+  overflow-x: auto;
+}
+
+.leaderboardTable {
+  width: 100%;
+  min-width: 480px;
+  border-collapse: separate;
+  border-spacing: 0 0.5rem;
+}
+
+.leaderboardTable th {
+  text-align: left;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8b5e3c;
+  padding: 0 1rem;
+}
+
+.leaderboardTrendColumn,
+.leaderboardScoreColumn {
+  text-align: right;
+}
+
+.leaderboardRow {
+  background: rgba(139, 94, 60, 0.1);
+  border-radius: 14px;
+}
+
+.leaderboardRow td {
+  padding: 0.75rem 1rem;
+  vertical-align: middle;
+}
+
+.leaderboardRow td:first-child {
+  border-top-left-radius: 14px;
+  border-bottom-left-radius: 14px;
+}
+
+.leaderboardRow td:last-child {
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
+}
+
+.leaderboardMeRow {
+  background: rgba(139, 94, 60, 0.22);
+  box-shadow: 0 0 0 2px rgba(139, 94, 60, 0.4) inset;
+}
+
+.leaderboardMeRow td {
+  font-weight: 700;
+}
+
+.leaderboardRankCell {
+  width: 4rem;
+  font-weight: 700;
+  color: #5a3b33;
+}
+
+.leaderboardNameCell {
+  font-weight: 600;
+}
+
+.leaderboardTrendCell,
+.leaderboardScoreCell {
+  text-align: right;
+  font-weight: 600;
+}
+
+.leaderboardTrendIndicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  font-weight: 700;
+  color: #6f4a3f;
+}
+
+.leaderboardTrendUp {
+  color: #2f7a33;
+}
+
+.leaderboardTrendDown {
+  color: #b02318;
+}
+
+.leaderboardStatus {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: #6f4a3f;
+}
+
+.leaderboardTrend {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #5a3b33;
+}
+
+.leaderboardSessionMeta {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #6f4a3f;
+}
+
+@media (max-width: 600px) {
+  .leaderboardControls {
+    align-items: stretch;
+  }
+
+  .leaderboardSelect {
+    width: 100%;
+  }
+
+  .leaderboardTable th,
+  .leaderboardRow td {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add API contracts and endpoint to return coffee bar leaderboard standings with trend tracking
- surface a leaderboard view in the coffee bar client with a session filter, refresh control, and personal trend messaging
- style the leaderboard card and table to match the existing Coffee Talk aesthetic

## Testing
- dotnet build
- dotnet test
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e567d845a8832b912e99a7d926938a